### PR TITLE
Two small fixes

### DIFF
--- a/scripts/dev/quickstyle.sh
+++ b/scripts/dev/quickstyle.sh
@@ -31,7 +31,8 @@ function gostyle() {
 	local gofiles
 	IFS=$'\n' read -d '' -r -a gofiles < <(
 		printf '%s\n' "${changed_files[@]}" |
-		grep '\.go$'
+		grep '\.go$' |
+		grep -v 'mocks/'
 	)
 	[[ "${#gofiles[@]}" == 0 ]] && return 0
 	einfo "Running go style checks..."

--- a/setup/osx.sh
+++ b/setup/osx.sh
@@ -14,9 +14,21 @@ else
 	einfo "Found Homebrew."
 fi
 
+packages=(jq)
+
 einfo "Installing missing packages, if any ..."
-brew install jq 2>/dev/null
-[[ $? -eq 0 && -x "$(command -v jq)" ]] || \
+IFS=$'\n' read -d '' -r -a missing_packages < <(
+	{
+		brew ls --versions "${packages[@]}" | awk '{print$1}'
+		printf "%s\n" "${packages[@]}"
+	} | sort | uniq -u
+)
+status=0
+if [[ "${#missing_packages[@]}" > 0 ]]; then
+	brew install "${missing_packages[@]}"
+	status=$?
+fi
+[[ $status == 0 && -x "$(command -v jq)" ]] || \
 	die "Failed to install required packages"
 
 check_env_installed


### PR DESCRIPTION
1. Ignore `mocks` when applying `quickstyle`.
2. Change the osx setup script to only install packages that are not yet installed (as `brew` does not have an idempotent install command that doesn't error if packages are already installed)