### PR TITLE
move roxcurl from D&R to Rox

### DIFF
--- a/scripts/runtime/roxcurl.sh
+++ b/scripts/runtime/roxcurl.sh
@@ -1,30 +1,43 @@
 #!/usr/bin/env bash
 
-# Curls the StackRox director at the endpoint specified.
-# Assumes that you have an authenticated roxc running, and that you have ROX_DIRECTOR_IP set.
-# Example usage: roxcurl v1/ml/status
+# Curls StackRox central at the endpoint specified. If you
+# don't supply a fully qualified URL, assumes that central is
+# port-forwarded to localhost:8000 or that ROX_BASE_URL is set.
+#
+# Uses ROX_AUTH_TOKEN for authentication. If not set,
+# it reads the default admin password from standard deploy.sh
+# in deploy/k8s/central-deploy/password
+#
+# Example usage: roxcurl v1/imageIntegrations
+
+set -eu
 
 SCRIPT="$(python -c "import os; print(os.path.realpath('$0'))")"
 source "$(dirname "$SCRIPT")/../../lib/common.sh"
 
-: ${rox_url:=https://localhost:8000}
+: ${ROX_BASE_URL:=https://localhost:8000}
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 url [curl options...]"
+    exit 2
+fi
 
 url="$1"
 shift
 
 if [[ ! "$url" =~ ^https?:// ]]; then
-	url="${rox_url%/}/${url#/}"
+	url="${ROX_BASE_URL%/}/${url#/}"
 fi
 
 auth=()
-if [[ -z "${rox_token}" ]]; then
-    : ${rox_dir:=${GOPATH?${HOME}/go}/src/github.com/stackrox/rox}
-    password_file="${rox_dir}/deploy/k8s/central-deploy/password"
+if [[ -z "${ROX_AUTH_TOKEN-}" ]]; then
+    : ${ROX_DIR:=${GOPATH?${HOME}/go}/src/github.com/stackrox/rox}
+    password_file="${ROX_DIR}/deploy/k8s/central-deploy/password"
     if [[ -f "${password_file}" ]]; then
 	auth=(-u "admin:$(cat "${password_file}")")
     fi
 else
-    auth=(-H "Authorization: Bearer ${rox_token}")
+    auth=(-H "Authorization: Bearer ${ROX_AUTH_TOKEN}")
 fi
 
 curl -sSk "${auth[@]}" "$url" "$@"


### PR DESCRIPTION
It relies on, if present, the password file from deploy.sh. You can override that with -u or -H if you want. This could probably be a lot more generic, but it does save a lot of typing for me so I figured I'd share.