### PR TITLE
Check for minimum kubectl version in teardown script

### DIFF
--- a/scripts/runtime/teardown.sh
+++ b/scripts/runtime/teardown.sh
@@ -6,9 +6,10 @@ SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BA
 source "$(dirname "$SCRIPT")/../../lib/common.sh"
 
 check_kubectl_version() {
+  local major_version
+  major_version="$(kubectl version -o json --client | jq '.clientVersion.major // empty' -r)"
   local minor_version
-  major_version="$(kubectl version -o json --client | jq '.clientVersion.major' -r)"
-  minor_version="$(kubectl version -o json --client | jq '.clientVersion.minor' -r)"
+  minor_version="$(kubectl version -o json --client | jq '.clientVersion.minor // empty' -r)"
   [[ -n "${major_version}" && -n "${minor_version}" ]] || die "Couldn't check kubectl version"
   (( major_version > 1 || minor_version > 12 )) || die "You need to upgrade your kubectl for this to work. If on Mac OS, run { brew install kubernetes-cli || brew upgrade kubernetes-cli; } && brew link --overwrite kubernetes-cli"
 }


### PR DESCRIPTION
Everyone seems to hit this the first time they run teardown because `gcloud` is still on an ancient version.