### PR TITLE
Teardown: add docker-desktop to well-known dev environments

### DIFF
--- a/scripts/runtime/teardown.sh
+++ b/scripts/runtime/teardown.sh
@@ -16,7 +16,7 @@ check_kubectl_version() {
 
 check_kubectl_version
 
-well_known_dev_context_regexes=(docker-for-desktop minikube gke.*setup-dev.*)
+well_known_dev_context_regexes=(docker-desktop docker-for-desktop minikube gke.*setup-dev.*)
 
 current_context="$(kubectl config current-context)"
 


### PR DESCRIPTION
Docker has rebranded as "Docker Desktop" in recent versions and its
Kubernetes cluster is now called "docker-desktop" instead of
"docker-for-desktop".

At least that's what my cluster is called after upgrading to this version:

<img width="848" alt="Screen Shot 2019-08-14 at 10 49 18 AM" src="https://user-images.githubusercontent.com/525265/63043695-9a485100-be81-11e9-9f6b-b94410dc2547.png">

(They said the upgrade would involve deploying a new k8s cluster.)