### PR TITLE
Teardown: delete hostpath if on docker-desktop

### DIFF
--- a/scripts/runtime/teardown.sh
+++ b/scripts/runtime/teardown.sh
@@ -52,7 +52,7 @@ fi
 
 if [[ "${current_context}" == "docker-desktop" ]]; then
   einfo "On docker-desktop, deleting hostpath (if it exists)"
-  docker run --rm -it -v /:/vm-root alpine:edge rm -rf /var/lib/stackrox
+  docker run --rm -it -v /:/vm-root alpine:edge rm -rf /vm-root/var/lib/stackrox
 fi
 
 einfo "Teardown complete."


### PR DESCRIPTION
This makes it easy to deploy with persistence locally.