### PR TITLE
Delete horizontal pod autoscaler in teardown

### DIFF
--- a/scripts/runtime/teardown.sh
+++ b/scripts/runtime/teardown.sh
@@ -36,7 +36,7 @@ fi
 kubectl -n stackrox delete --grace-period=0 --force deploy/central deploy/sensor ds/collector deploy/monitoring
 kubectl -n stackrox get application -o name | xargs kubectl -n stackrox delete --wait
 #
-kubectl -n stackrox get cm,deploy,ds,networkpolicy,secret,svc,serviceaccount,validatingwebhookconfiguration -o name | xargs kubectl -n stackrox delete --wait
+kubectl -n stackrox get cm,deploy,ds,hpa,networkpolicy,secret,svc,serviceaccount,validatingwebhookconfiguration -o name | xargs kubectl -n stackrox delete --wait
 # Only delete RBAC/PSP-related resources that contain "stackrox"
 kubectl -n stackrox get clusterrole,clusterrolebinding,role,rolebinding,psp -o name | grep stackrox | xargs kubectl -n stackrox delete --wait
 


### PR DESCRIPTION
We now create an HPA for the scanner. Add this to the list of resources that `teardown` destroys.