### PR TITLE
Fix teardown.sh to remove the edit Role and manage-namespace RoleBinding

### DIFF
--- a/scripts/runtime/teardown.sh
+++ b/scripts/runtime/teardown.sh
@@ -36,9 +36,9 @@ fi
 kubectl -n stackrox delete --grace-period=0 --force deploy/central deploy/sensor ds/collector deploy/monitoring
 kubectl -n stackrox get application -o name | xargs kubectl -n stackrox delete --wait
 #
-kubectl -n stackrox get cm,deploy,ds,hpa,networkpolicy,secret,svc,serviceaccount,validatingwebhookconfiguration -o name | xargs kubectl -n stackrox delete --wait
-# Only delete RBAC/PSP-related resources that contain "stackrox"
-kubectl -n stackrox get clusterrole,clusterrolebinding,role,rolebinding,psp -o name | grep stackrox | xargs kubectl -n stackrox delete --wait
+kubectl -n stackrox get cm,deploy,ds,hpa,networkpolicy,role,rolebinding,secret,svc,serviceaccount,validatingwebhookconfiguration -o name | xargs kubectl -n stackrox delete --wait
+# Only delete cluster-wide RBAC/PSP-related resources that contain "stackrox"
+kubectl -n stackrox get clusterrole,clusterrolebinding,psp -o name | grep stackrox | xargs kubectl -n stackrox delete --wait
 
 ## DO NOT RUN THIS IN A CUSTOMER ENVIRONMENT, IT WILL DELETE ALL THEIR DATA
 ## AND THEY WILL NEVER TALK TO US AGAIN.


### PR DESCRIPTION
```
khushboo@Khushboos-MacBook-Pro:~/go/src/github.com/workflow$ ./scripts/runtime/teardown.sh 
warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
deployment.extensions "central" force deleted
deployment.extensions "sensor" force deleted
daemonset.extensions "collector" force deleted
Error from server (NotFound): deployments.extensions "monitoring" not found
application.app.k8s.io "stackrox" deleted
configmap "admission-control" deleted
configmap "central-config" deleted
configmap "central-endpoints" deleted
deployment.extensions "admission-control" deleted
networkpolicy.extensions "admission-control-no-ingress" deleted
networkpolicy.extensions "allow-ext-to-central" deleted
networkpolicy.extensions "collector-no-ingress" deleted
networkpolicy.extensions "sensor" deleted
role.rbac.authorization.k8s.io "edit" deleted
role.rbac.authorization.k8s.io "stackrox-central-diagnostics" deleted
role.rbac.authorization.k8s.io "watch-config" deleted
rolebinding.rbac.authorization.k8s.io "admission-control-watch-config" deleted
rolebinding.rbac.authorization.k8s.io "manage-namespace" deleted
rolebinding.rbac.authorization.k8s.io "stackrox-admission-control-psp" deleted
rolebinding.rbac.authorization.k8s.io "stackrox-central-diagnostics" deleted
rolebinding.rbac.authorization.k8s.io "stackrox-central-psp" deleted
rolebinding.rbac.authorization.k8s.io "stackrox-collector-psp" deleted
rolebinding.rbac.authorization.k8s.io "stackrox-sensor-psp" deleted
secret "additional-ca-sensor" deleted
secret "admission-control-tls" deleted
secret "admission-control-token-x5gzp" deleted
secret "central-htpasswd" deleted
secret "central-license" deleted
secret "central-tls" deleted
secret "central-token-8j657" deleted
secret "collector-stackrox" deleted
secret "collector-tls" deleted
secret "collector-token-2wz9x" deleted
secret "default-token-xh57z" deleted
secret "proxy-config" deleted
secret "sensor-tls" deleted
secret "sensor-token-4dz4p" deleted
secret "sensor-upgrader-token-8mg4k" deleted
secret "sh.helm.release.v1.sensor.v1" deleted
secret "stackrox" deleted
service "admission-control" deleted
service "central" deleted
service "sensor" deleted
service "sensor-webhook" deleted
serviceaccount "admission-control" deleted
serviceaccount "central" deleted
serviceaccount "collector" deleted
serviceaccount "default" deleted
serviceaccount "sensor" deleted
serviceaccount "sensor-upgrader" deleted
validatingwebhookconfiguration.admissionregistration.k8s.io "stackrox" deleted
clusterrole.rbac.authorization.k8s.io "stackrox-admission-control-psp" deleted
clusterrole.rbac.authorization.k8s.io "stackrox-central-psp" deleted
clusterrole.rbac.authorization.k8s.io "stackrox-collector-psp" deleted
clusterrole.rbac.authorization.k8s.io "stackrox-sensor-psp" deleted
clusterrole.rbac.authorization.k8s.io "stackrox:create-events" deleted
clusterrole.rbac.authorization.k8s.io "stackrox:edit-workloads" deleted
clusterrole.rbac.authorization.k8s.io "stackrox:network-policies" deleted
clusterrole.rbac.authorization.k8s.io "stackrox:update-namespaces" deleted
clusterrole.rbac.authorization.k8s.io "stackrox:view-cluster" deleted
clusterrolebinding.rbac.authorization.k8s.io "stackrox:create-events-binding" deleted
clusterrolebinding.rbac.authorization.k8s.io "stackrox:enforce-policies" deleted
clusterrolebinding.rbac.authorization.k8s.io "stackrox:monitor-cluster" deleted
clusterrolebinding.rbac.authorization.k8s.io "stackrox:network-policies-binding" deleted
clusterrolebinding.rbac.authorization.k8s.io "stackrox:update-namespaces-binding" deleted
clusterrolebinding.rbac.authorization.k8s.io "stackrox:upgrade-sensors" deleted
podsecuritypolicy.extensions "stackrox-admission-control" deleted
podsecuritypolicy.extensions "stackrox-central" deleted
podsecuritypolicy.extensions "stackrox-collector" deleted
podsecuritypolicy.extensions "stackrox-sensor" deleted
persistentvolume "pvc-7e0d5e03-90ca-11ea-8ca7-42010a8a00bd" deleted
persistentvolumeclaim "stackrox-db" deleted
[INFO] Teardown complete.
khushboo@Khushboos-MacBook-Pro:~/go/src/github.com/workflow$ kc get roles
No resources found.
khushboo@Khushboos-MacBook-Pro:~/go/src/github.com/workflow$ kc get rolebindings
No resources found.
```