### PR TITLE
Make teardown safer by separating out globally-scoped resources

### DIFF
--- a/scripts/runtime/teardown.sh
+++ b/scripts/runtime/teardown.sh
@@ -45,7 +45,7 @@ kubectl -n stackrox get application -o name | xargs kubectl -n stackrox delete -
 # DO NOT ADD ANY NON-NAMESPACED RESOURCES TO THIS LIST, OTHERWISE ALL RESOURCES IN THE CLUSTER OF THAT TYPE
 # WILL BE DELETED!
 kubectl -n stackrox get cm,deploy,ds,hpa,networkpolicy,role,rolebinding,secret,svc,serviceaccount,pvc -o name | xargs kubectl -n stackrox delete --wait
-# Only delete cluster-wide RBAC/PSP-related resources that contain "stackrox"
+# Only delete cluster-wide RBAC/PSP-related resources that contain have the app.kubernetes.io/name=stackrox label.
 kubectl -n stackrox get clusterrole,clusterrolebinding,psp,validatingwebhookconfiguration -o name -l app.kubernetes.io/name=stackrox | xargs kubectl -n stackrox delete --wait
 
 ## DO NOT RUN THIS IN A CUSTOMER ENVIRONMENT, IT WILL DELETE ALL THEIR DATA


### PR DESCRIPTION
Some delete commands include an `-n stackrox` parameter, but reference non-namespaced resources. This means that all resources of that type will be deleted, cluster-wide. This is bad.

Change the delete commands to only delete global resources that have the StackRox app label. Perform special handling for PVs, and only delete PVs that were referenced pre-teardown by PVCs in the StackRox namespace.