### PR TITLE
Update quickstyle to not run fmt/lint/vet/imports if covered in golangci-lint

### DIFF
--- a/setup/osx.sh
+++ b/setup/osx.sh
@@ -3,6 +3,7 @@
 SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../lib/common.sh"
 source "$(dirname "$SCRIPT")/../lib/shell_config.sh"
+source "$(dirname "$SCRIPT")/../setup/packages.sh"
 
 einfo "Checking for Homebrew ..."
 if [[ ! -x "$(command -v brew)" ]]; then
@@ -14,13 +15,11 @@ else
 	einfo "Found Homebrew."
 fi
 
-packages=(jq)
-
 einfo "Installing missing packages, if any ..."
 IFS=$'\n' read -d '' -r -a missing_packages < <(
 	{
-		brew ls --versions "${packages[@]}" | awk '{print$1}'
-		printf "%s\n" "${packages[@]}"
+		brew ls --versions "${REQUIRED_PACKAGES[@]}" | awk '{print$1}'
+		printf "%s\n" "${REQUIRED_PACKAGES[@]}"
 	} | sort | uniq -u
 )
 status=0

--- a/setup/packages.sh
+++ b/setup/packages.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Dependent packages
+REQUIRED_PACKAGES=(yq jq)
+
+function check_dependencies() {
+  local missing
+  missing=()
+
+  # Scan for missing packages
+  for pkg in "${REQUIRED_PACKAGES[@]}"
+  do
+    if [[ ! -x "$(command -v "${pkg}")" ]]; then
+      missing+=("$pkg")
+    fi
+  done
+
+  if [[ "${missing}" != "" ]]; then
+    local setup_path
+    setup_path="$(dirname "${SCRIPT}")/../../setup.sh"
+    efatal "Dependent packages are missing: ${missing[*]}"
+    efatal "Please run ${setup_path}"
+    exit 1
+  fi
+}
+

--- a/setup/ubuntu.sh
+++ b/setup/ubuntu.sh
@@ -3,17 +3,16 @@
 SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../lib/common.sh"
 source "$(dirname "$SCRIPT")/../lib/shell_config.sh"
+source "$(dirname "$SCRIPT")/../setup/packages.sh"
 
 : ${SUDO:=sudo}
 
-PACKAGES=("jq")
-
-dpkg -s "${PACKAGES[@]}" > /dev/null
+dpkg -s "${REQUIRED_PACKAGES[@]}" > /dev/null
 
 if [[ "$?" -ne 0 ]] ; then
   echo Installing missing packages
   set -x
-  "${SUDO}" apt install "${PACKAGES[@]}"
+  "${SUDO}" apt install "${REQUIRED_PACKAGES[@]}"
   set +x
 fi
 


### PR DESCRIPTION
Basically piggy backing on the changes in https://github.com/stackrox/rox/pull/5998 -- don't do unnecessary double runs of fmt/lint/vet/imports. Still need to be compatible with other repos + backward-compatible with rox, so don't remove the code altogether -- just inspect the GolangCI config and use that to decide whether to run the others.