### PR TITLE
Add .ts and .tsx extensions to FE check

### DIFF
--- a/scripts/dev/quickstyle.sh
+++ b/scripts/dev/quickstyle.sh
@@ -142,7 +142,7 @@ function jsstyle() {
 	local status
 	IFS=$'\n' read -d '' -r -a jsfiles < <(
 		printf '%s\n' "${changed_files[@]}" |
-		grep "${gitroot}/ui/.*(js|tsx|ts)$"
+		egrep "${gitroot}/ui/.*(js|tsx|ts)$"
 	)
 	[[ "${#jsfiles[@]}" -eq 0 ]] && return 0
 	einfo "Running JS style checks..."


### PR DESCRIPTION
These changes are not working.

Steps I have taken to debug:
* Verified that the command in the line  `git diff "$diffbase" --name-status .` finds a changed file
* Verified that both new regexs work, on https://regexr.com/
* Verified that a raw run of eslint with the npm script which checks all files, `yarn lint`, finds an error I purposeful introduced

But putting that all together, the modified `quickstyle` does not show an error in a TS file.