### PR TITLE
Added user flag to enable sudo-less installs

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,7 @@ if ! "${PYTHON_INTERPRETER}" -m pip --version &> /dev/null; then
 fi
 
 einfo "Installing python packages"
-"${PYTHON_INTERPRETER}" -m pip install -r "$(dirname "${SCRIPT}")/requirements.txt"
+"${PYTHON_INTERPRETER}" -m pip install --user -r "$(dirname "${SCRIPT}")/requirements.txt"
 
 platform="$(uname)"
 


### PR DESCRIPTION
Currently, we're installing Python packages system-wide, which is not optimal as the default Python3-installation is OS-managed and subject to external changes. 
By appending the `--user` flag to the install command, packages are installed into the user dir, still available system-wide but tucked away in the user home. As our dev machines are used only by a single person, this will have no impact on daily life.
It also enables us to run setup.sh without sudo. This fixes #65.

I have verified this working by uninstalling my system Python3 packages and running setup.sh again with the user flag. Afterwards, I was able to observe requests being available in the system Python3 prompt & pip freeze as usual