### PR TITLE
Use offline-compatible method for determining default branch

### DIFF
--- a/scripts/dev/quickstyle.sh
+++ b/scripts/dev/quickstyle.sh
@@ -213,7 +213,8 @@ if [[ -f "${gitroot}/go.mod" ]]; then
 	export GO111MODULE=on
 fi
 
-main_branch="$(git rev-parse --symbolic-full-name origin/HEAD | sed 's@^refs/remotes/origin/@@')"
+# https://stackoverflow.com/a/44750379
+main_branch="$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')"
 [[ -n "${main_branch}" ]] || die "Failed to get main branch"
 
 diffbase="$(git merge-base HEAD "origin/${main_branch}")"


### PR DESCRIPTION
The current `git remote show`-based method requires an internet connection/access to the remote. This is annoying in environments when you don't have access to the internet (e.g., flights), or if the connection is poor.

The method here has some drawbacks (see comments on https://stackoverflow.com/a/44750379) compared to the previous method, most of which are not relevant to us. Perhaps the most relevant thing is that updates of the main branch are not reflected until `git remote set-head origin --auto`. However, this seems tolerable for our purposes.