### PR TITLE
Fallback correctly to home directory if GOPATH is not set when retrieving the password_file

### DIFF
--- a/lib/rox_password.sh
+++ b/lib/rox_password.sh
@@ -37,7 +37,7 @@ _get_rox_admin_password() {
     	return 2
     fi
 
-    : ${ROX_DIR:=${GOPATH?${HOME}/go}/src/github.com/stackrox/rox}
+    : ${ROX_DIR:=${GOPATH:-${HOME}/go}/src/github.com/stackrox/rox}
 	password_file="${ROX_DIR}/deploy/${orch}/central-deploy/password"
 
 	if [[ ! -f "$password_file" ]]; then


### PR DESCRIPTION
When invoking commands such as "logmein" without the `GOPATH` environment variable being set correctly, the script would fail with the following error:
`
zsh/bash: GOPATH: ${HOME}/go
`

Now, evaluated the GOPATH / HOME variables correctly to fallback to the user's home directory when `GOPATH` is not set.