### PR TITLE
remove proxies on teardown

### DIFF
--- a/scripts/runtime/teardown.sh
+++ b/scripts/runtime/teardown.sh
@@ -71,4 +71,11 @@ if [[ "${current_context}" == "docker-desktop" ]]; then
   docker run --rm -it -v /:/vm-root alpine:edge rm -rf /vm-root/var/lib/stackrox
 fi
 
+kubectl get ns proxies &> /dev/null
+has_proxies=$?
+if [[ $has_proxies == 0 ]]; then
+	einfo "Deleting proxies namespace"
+	kubectl delete namespace proxies
+fi
+
 einfo "Teardown complete."


### PR DESCRIPTION
If proxies were added using [scripts/ci/proxy/deploy.sh](https://github.com/stackrox/rox/blob/master/scripts/ci/proxy/deploy.sh); they should be removed with `teardown` as well. 