### PR TITLE
Use python3 rather than unversioned python.

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -19,7 +19,7 @@ if [[ -z "$SCRIPT" ]]; then
   return
 fi
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$SCRIPT")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$SCRIPT")"
 
 ROX_WORKFLOW_BIN="$(dirname "$SCRIPT")/bin"
 ROX_WORKFLOW_BIN="$(cd "$ROX_WORKFLOW_BIN"; pwd)"

--- a/lib/bitbucket.sh
+++ b/lib/bitbucket.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/git.sh"
 
 if [[ -f "$CONFIG_FILE" ]]; then

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -3,7 +3,7 @@
 CONFIG_FILE="$HOME/.stackrox/workflow-config.json"
 
 ROX_WORKFLOW_WORKDIR="$HOME/.roxworkflow-workdir"
-PYTHON_INTERPRETER="$(which python3 || which python)"
+PYTHON_INTERPRETER="$(which python3)"
 
 bold="$(tput bold)"
 reset="$(tput sgr0)"

--- a/lib/gcp.sh
+++ b/lib/gcp.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/common.sh"
 
 if [[ -f "$CONFIG_FILE" ]]; then

--- a/lib/git.sh
+++ b/lib/git.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/common.sh"
 
 # Gets the current branch.

--- a/lib/github.sh
+++ b/lib/github.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/common.sh"
 source "$(dirname "$SCRIPT")/git.sh"
 

--- a/lib/rox_password.sh
+++ b/lib/rox_password.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-pushd >/dev/null "$(dirname "$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")")"
+pushd >/dev/null "$(dirname "$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")")"
 source "common.sh"
 popd >/dev/null
 

--- a/scripts/dev/checkout-pr.sh
+++ b/scripts/dev/checkout-pr.sh
@@ -4,13 +4,13 @@
 # You WILL need to have your Github or Bitbucket creds checked in to ~/.stackrox/workflow-config.json for this to work.
 # Usage: checkout-pr <pr #> (while inside the repo)
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/git.sh"
 
 service="$(bitbucket_or_github)"
 [[ $? -eq 0 ]] || die
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/${service}.sh"
 
 branch="$(get_branch_from_pr "$1")"

--- a/scripts/dev/cycle-branch.sh
+++ b/scripts/dev/cycle-branch.sh
@@ -15,7 +15,7 @@
 #   cycle-branch -c 2    Checks out the second-last branch that was checked out
 #                        previously.
 
-pushd >/dev/null "$(dirname "$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")")"
+pushd >/dev/null "$(dirname "$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")")"
 source "../../lib/common.sh"
 source "../../lib/git.sh"
 popd >/dev/null

--- a/scripts/dev/getprnumber.sh
+++ b/scripts/dev/getprnumber.sh
@@ -4,13 +4,13 @@
 # You WILL need to have your Github or Bitbucket creds checked in to ~/.stackrox/workflow-config.json for this to work.
 # Usage: getprnumber (while inside the repo, with the branch you care about checked out.)
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/git.sh"
 
 service="$(bitbucket_or_github)"
 [[ $? -eq 0 ]] || die
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/${service}.sh"
 
 

--- a/scripts/dev/gogen.sh
+++ b/scripts/dev/gogen.sh
@@ -4,7 +4,7 @@
 # argument, if any), but with the PATH expected for mockgen-wrapper to work.
 # Usage: gogen [<directory>] (while inside the rox repo).
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/common.sh"
 
 gitroot="$(git rev-parse --show-toplevel)"

--- a/scripts/dev/openbranch.sh
+++ b/scripts/dev/openbranch.sh
@@ -3,13 +3,13 @@
 # Opens the web page corresponding to the currently checked-out branch of the repo you're in.
 # Usage: openbranch (while inside the repo, with the branch you want to open checked out.)
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/git.sh"
 
 service="$(bitbucket_or_github)"
 [[ $? -eq 0 ]] || die
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/${service}.sh"
 
 branch_url="$(get_branch_url)"

--- a/scripts/dev/openjira.sh
+++ b/scripts/dev/openjira.sh
@@ -6,7 +6,7 @@
 #
 # Usage: openjira (while inside the repo, with the branch you want to open checked out.)
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/git.sh"
 
 function browse_ticket_number() {
@@ -33,7 +33,7 @@ einfo "Couldn't find the JIRA number in your branch name. Checking if you have i
 service="$(bitbucket_or_github)"
 [[ $? -eq 0 ]] || die
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/${service}.sh"
 
 

--- a/scripts/dev/openpr.sh
+++ b/scripts/dev/openpr.sh
@@ -4,13 +4,13 @@
 # You WILL need to have your GitHub or Bitbucket creds checked in to ~/.stackrox/workflow-config.json for this to work.
 # Usage: openpr (while inside the repo, with the branch you want to open checked out.)
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/git.sh"
 
 service="$(bitbucket_or_github)"
 [[ $? -eq 0 ]] || die
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/${service}.sh"
 
 pr_url="$(get_pr_url)"

--- a/scripts/dev/quickstyle.sh
+++ b/scripts/dev/quickstyle.sh
@@ -5,7 +5,7 @@
 # However, it is not guaranteed to be correct. (Although it should be 99% of the time.)
 # Usage: quickstyle (while inside the rox repo)
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/common.sh"
 source "$(dirname "$SCRIPT")/../../setup/packages.sh"
 

--- a/scripts/dev/roxlatesttag.sh
+++ b/scripts/dev/roxlatesttag.sh
@@ -4,7 +4,7 @@
 # By default it displays the main image.
 # roxlatesttag <SERVICE_NAME>
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 DIR="$(dirname "$SCRIPT")"
 
 image=$1

--- a/scripts/dev/smart-branch.sh
+++ b/scripts/dev/smart-branch.sh
@@ -2,7 +2,7 @@
 
 #Usage: smart-branch (creates and checks out a new branch with marker commits to allow working on multiple dependend branches)
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/git.sh"
 
 [[ $# > 0 && $# < 3 ]] || die "Usage: $0 <branch-name> [<parent-branch>]"

--- a/scripts/dev/smart-diff.sh
+++ b/scripts/dev/smart-diff.sh
@@ -2,7 +2,7 @@
 
 # Produces git diff relative to the last smart-branch commit.
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/git.sh"
 
 marker_commit="$(git log --grep="^X-Smart-Branch-Parent: " --format="%H" --max-count=1)"

--- a/scripts/dev/smart-rebase.sh
+++ b/scripts/dev/smart-rebase.sh
@@ -2,7 +2,7 @@
 
 #Usage: smart-rebase (given a branch name it rebases multiple dependend branches)
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/git.sh"
 
 target_branch="$1"

--- a/scripts/dev/smart-squash.sh
+++ b/scripts/dev/smart-squash.sh
@@ -2,7 +2,7 @@
 
 #Usage: smart-squash (squashes commits only until the first parent branch marker)
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/git.sh"
 
 git diff-index --quiet HEAD || die "Current working directory must be clean before rebasing."

--- a/scripts/gcp/gcdown.sh
+++ b/scripts/gcp/gcdown.sh
@@ -2,7 +2,7 @@
 
 # Brings down the GCP dev VM.
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/common.sh"
 source "$(dirname "$SCRIPT")/../../lib/gcp.sh"
 

--- a/scripts/gcp/gcmosh.sh
+++ b/scripts/gcp/gcmosh.sh
@@ -5,7 +5,7 @@
 # Usage:
 #  gcmosh               Enters a login shell on the dev VM using mosh.
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/common.sh"
 source "$(dirname "$SCRIPT")/../../lib/gcp.sh"
 

--- a/scripts/gcp/gcscp.sh
+++ b/scripts/gcp/gcscp.sh
@@ -7,7 +7,7 @@
 # Usage:
 #  gcscp [:]<source1> [...] [:]<dest>
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/common.sh"
 source "$(dirname "$SCRIPT")/../../lib/gcp.sh"
 

--- a/scripts/gcp/gcssh.sh
+++ b/scripts/gcp/gcssh.sh
@@ -7,7 +7,7 @@
 #                       is set up to use tmux, will enter a tmux session.
 #  gcssh <command...>   Runs <command...> on the dev VM.
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/common.sh"
 source "$(dirname "$SCRIPT")/../../lib/gcp.sh"
 

--- a/scripts/gcp/gcup.sh
+++ b/scripts/gcp/gcup.sh
@@ -2,7 +2,7 @@
 
 # Brings up the GCP dev VM.
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/common.sh"
 source "$(dirname "$SCRIPT")/../../lib/gcp.sh"
 

--- a/scripts/runtime/killpf.sh
+++ b/scripts/runtime/killpf.sh
@@ -2,7 +2,7 @@
 
 # killpf <port> kills a kubectl port-forward running on the passed port, if there is one. Note that it ONLY kills kubectl port-forwards, not arbtirary processes.
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/common.sh"
 
 port="$1"

--- a/scripts/runtime/logmein.sh
+++ b/scripts/runtime/logmein.sh
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-pushd >/dev/null "$(dirname "$(python -c "import os; print(os.path.realpath('$0'))")")"
+pushd >/dev/null "$(dirname "$(python3 -c "import os; print(os.path.realpath('$0'))")")"
 source "../../lib/common.sh"
 source "../../lib/rox_password.sh"
 popd >/dev/null

--- a/scripts/runtime/roxcurl.sh
+++ b/scripts/runtime/roxcurl.sh
@@ -17,7 +17,7 @@
 
 set -eu
 
-pushd >/dev/null "$(dirname "$(python -c "import os; print(os.path.realpath('$0'))")")"
+pushd >/dev/null "$(dirname "$(python3 -c "import os; print(os.path.realpath('$0'))")")"
 source "../../lib/common.sh"
 source "../../lib/rox_password.sh"
 popd >/dev/null

--- a/scripts/runtime/roxkubectx.sh
+++ b/scripts/runtime/roxkubectx.sh
@@ -5,6 +5,6 @@
 # Please just use `kubectl config current-context` (or your own alias for it) instead.
 
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 
 kubectl config current-context

--- a/scripts/runtime/teardown.sh
+++ b/scripts/runtime/teardown.sh
@@ -2,7 +2,7 @@
 
 # Tears down a running StackRox installation very quickly, and makes sure no resources we create are left running around.
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/common.sh"
 
 check_kubectl_version() {

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/lib/common.sh"
 
 einfo "Check pip installation, using ${PYTHON_INTERPRETER}"

--- a/setup/osx.sh
+++ b/setup/osx.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../lib/common.sh"
 source "$(dirname "$SCRIPT")/../lib/shell_config.sh"
 source "$(dirname "$SCRIPT")/../setup/packages.sh"

--- a/setup/packages.sh
+++ b/setup/packages.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PACKAGES_PATH="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+PACKAGES_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$PACKAGES_PATH")/../lib/common.sh"
 
 # Dependent packages

--- a/setup/ubuntu.sh
+++ b/setup/ubuntu.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SCRIPT="$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../lib/common.sh"
 source "$(dirname "$SCRIPT")/../lib/shell_config.sh"
 source "$(dirname "$SCRIPT")/../setup/packages.sh"


### PR DESCRIPTION
A versioned Python executable (i.e. `python3` or `python2`) on `$PATH` is recommended these days, and versionless `python` is discouraged.
Neither RHEL 8.5 nor Debian 11 (both considered the opposite of "cutting edge") have an unversioned `python` by default.
At the same time they, as well as MacOS 11.6.1`, do have a `python3` on `$PATH`.