### PR TITLE
Remove scc stackrox-central-db on teardown

### DIFF
--- a/scripts/runtime/teardown.sh
+++ b/scripts/runtime/teardown.sh
@@ -60,7 +60,7 @@ kubectl -n stackrox get clusterrole,clusterrolebinding,psp,validatingwebhookconf
 [[ "${#stackrox_pvs[@]}" == 0 ]] || kubectl delete --wait pv "${stackrox_pvs[@]}"
 
 if kubectl api-versions | grep -q openshift.io; then
-  for scc in central monitoring scanner sensor stackrox-central stackrox-monitoring stackrox-scanner stackrox-sensor; do
+  for scc in central monitoring scanner sensor stackrox-central stackrox-monitoring stackrox-scanner stackrox-sensor stackrox-central-db; do
     oc delete scc $scc
   done
   oc delete route central -n stackrox


### PR DESCRIPTION
We add scc for central-db and we need to remove it on teardown.