### PR TITLE
add colima and rancher-desktop to teardown

### DIFF
--- a/scripts/runtime/teardown.sh
+++ b/scripts/runtime/teardown.sh
@@ -25,6 +25,8 @@ well_known_dev_context_regexes=(
   gke.*setup-dev.*
   gke_srox-temp-dev-test_.*
   .*openshift-infra-rox-systems.*
+  colima
+  rancher-desktop
 )
 
 current_context="$(kubectl config current-context)"


### PR DESCRIPTION
Since more people are switching to Docker Desktop alternatives, I would suggest adding colima and rancher-desktop to the well known context list.