### PR TITLE
ROX-14920: Add Alertmanager statefulset to teardown

### DIFF
--- a/scripts/runtime/teardown.sh
+++ b/scripts/runtime/teardown.sh
@@ -49,7 +49,7 @@ IFS=$'\n' read -d '' -r -a stackrox_pvs < <(
 )
 
 # Delete deployments quickly. If we add a new deployment and forget to add it here, it'll get caught in the next line anyway.
-kubectl -n stackrox delete --grace-period=0 --force deploy/central deploy/sensor ds/collector deploy/monitoring
+kubectl -n stackrox delete --grace-period=0 --force deploy/central deploy/sensor ds/collector deploy/monitoring statefulsets/stackrox-monitoring-alertmanager
 kubectl -n stackrox get application -o name | xargs kubectl -n stackrox delete --wait
 # DO NOT ADD ANY NON-NAMESPACED RESOURCES TO THIS LIST, OTHERWISE ALL RESOURCES IN THE CLUSTER OF THAT TYPE
 # WILL BE DELETED!


### PR DESCRIPTION
If deployed with MONITORING_ENABLED locally (e.g. to colima), `teardown` misses the statefulset, which means the `stackrox-monitoring-alertmanager` will keep running, which leaves the cluster in an unclean state.
Added the statefulset to the `delete` call, which leaves the cluster clean.

Tested on MacOS x86 / Colima. 