### PR TITLE
fix(scripts): fix trusted environments

### DIFF
--- a/scripts/runtime/teardown.sh
+++ b/scripts/runtime/teardown.sh
@@ -23,7 +23,7 @@ well_known_dev_context_regexes=(
   docker-for-desktop
   minikube
   gke.*setup-dev.*
-  gke_srox-temp-dev-test_.*
+  gke_acs-team-temp-dev_*
   .*openshift-infra-rox-systems.*
   colima
   rancher-desktop


### PR DESCRIPTION
# Description

With the change from `srox` to `acs-team` for our GKE infra, the teardown now doesn't recognize GKE infra clusters as "well-known" environments. This PR fixes that.

Error message when executing teardown:
```
[INFO] Detected that you're connected to cluster gke_acs-team-temp-dev_us-central1-a_dh-09-22-eatable-injury-trea, which is not a well-known dev environment. Are you sure you want to proceed with the teardown?
```


