### PR TITLE
feat: enable setup.sh for Fedora CSB & fix env for ZSH

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -27,7 +27,7 @@ ROX_WORKFLOW_BIN="$(cd "$ROX_WORKFLOW_BIN"; pwd)"
 # Export select Go environment variables with the GOENV prefix.
 while read set_expr; do
 	eval "GOENV_${set_expr}"
-done < <(go env | egrep '^(GOROOT|GOBIN|GOPATH)=')
+done < <(go env | grep -E '^(GOROOT|GOBIN|GOPATH)=')
 
 [[ -n "$GOENV_GOROOT" ]] && PATH="$PATH:${GOENV_GOROOT}"
 [[ -n "$GOENV_GOBIN" ]] && PATH="$PATH:${GOENV_GOBIN}"

--- a/setup.sh
+++ b/setup.sh
@@ -32,6 +32,9 @@ if [[ "$platform" == "Linux" ]]; then
   RedHatEnterprise)
     setup_script="rhel.sh"
     ;;
+  Fedora)
+    setup_script="rhel.sh"
+    ;;
   esac
 fi
 


### PR DESCRIPTION
This PR adds Fedora CSB to the known OSes setup.sh works on. 
As it is very similar to RHEL, we're calling the same setup script.

Also, `egrep` errors out on ZSH-based shells as deprecated, so it was replaced with `grep -E`.