### PR TITLE
Remove teardown kubectl version check, oc doesn't support it

### DIFF
--- a/scripts/runtime/teardown.sh
+++ b/scripts/runtime/teardown.sh
@@ -5,19 +5,6 @@
 SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 source "$(dirname "$SCRIPT")/../../lib/common.sh"
 
-check_kubectl_version() {
-  local major_version
-  major_version="$(kubectl version -o json --client | jq '.clientVersion.major // empty' -r)"
-  major_version="${major_version%+}"
-  local minor_version
-  minor_version="$(kubectl version -o json --client | jq '.clientVersion.minor // empty' -r)"
-  minor_version="${minor_version%+}"
-  [[ -n "${major_version}" && -n "${minor_version}" ]] || die "Couldn't check kubectl version"
-  (( major_version > 1 || minor_version > 12 )) || die "You need to upgrade your kubectl for this to work. If on Mac OS, run { brew install kubernetes-cli || brew upgrade kubernetes-cli; } && brew link --overwrite kubernetes-cli"
-}
-
-check_kubectl_version
-
 test_in_well_known_dev_context
 
 # Collect all stackrox PVs before we delete the respective PVCs.


### PR DESCRIPTION
Remove teardown kubectl version check, oc doesn't support this format.
Additionally kubectl 1.12 is from 2019, currently we are at 1.29. Therefore I think it is safe to remove this check.

Kubectl output with oc does not contian `major` and `minor` versions:

```
❯ kubectl version --client -o json
{
  "clientVersion": {
    "major": "",
    "minor": "",
    "gitVersion": "4.13.0-202308112024.p0.g17b7acc.assembly.stream-17b7acc",
    "gitCommit": "17b7accf8fd25125ce015cf4bea7d3cd3f336317",
    "gitTreeState": "clean",
    "buildDate": "2023-08-11T20:28:15Z",
    "goVersion": "go1.19.10 X:strictfipsruntime",
    "compiler": "gc",
    "platform": "linux/amd64"
  },
  "kustomizeVersion": "v4.5.7"
}
```