### PR TITLE
ROX-15724: rename kubeconfig contexts for easier merge

### DIFF
--- a/scripts/dev/infra-sync.sh
+++ b/scripts/dev/infra-sync.sh
@@ -94,7 +94,7 @@ kubecfg_merge() {
 
     echo "Merging kube configurations into ${infra_kubeconfig}"
     tmp_infra_kubeconfig=$(mktemp)
-    kubectl config view --flatten > "${tmp_infra_kubeconfig}"
+    kubectl config view --flatten -o json | jq -f rename-kubeconfig-ctx.jq > "${tmp_infra_kubeconfig}"
     mv "${tmp_infra_kubeconfig}" "${infra_kubeconfig}"
 }
 

--- a/scripts/dev/rename-kubeconfig-ctx.jq
+++ b/scripts/dev/rename-kubeconfig-ctx.jq
@@ -1,0 +1,60 @@
+. as $cfg
+| (
+  # Build context_map as an array of objects with name transformations.
+  $cfg.contexts
+  | map({
+      old_name: .name,
+      cluster: .context.cluster,
+      old_user: .context.user,
+      new_name: .context.cluster,
+      new_user: (.context.user + "@" + .context.cluster)
+    })
+) as $context_map
+# Reconstruct the config from scratch.
+| {
+  kind: $cfg.kind,
+  apiVersion: $cfg.apiVersion,
+  preferences: $cfg.preferences,
+  clusters: $cfg.clusters,
+  contexts: (
+    $context_map
+    | map({
+        name: .new_name,
+        context: {
+          cluster: .cluster,
+          user: .new_user
+        }
+      })
+  ),
+  users: (
+    $cfg.users
+    | map(
+        . as $user
+        | (
+            $context_map
+            | map(select(.old_user == $user.name))
+            | if length > 0 then
+                {
+                  name: .[0].new_user,
+                  user: $user.user
+                }
+              else
+                $user
+              end
+          )
+      )
+  ),
+}
+# Conditionally include current-context if it existed originally.
+| if $cfg | has("current-context") then
+  . + {
+    "current-context": (
+      $cfg["current-context"] as $curr
+      | $context_map
+      | map(select(.old_name == $curr))
+      | if length > 0 then .[0].new_name else $curr end
+    )
+  }
+else .
+end
+

--- a/scripts/dev/rename-kubeconfig-ctx.jq
+++ b/scripts/dev/rename-kubeconfig-ctx.jq
@@ -1,3 +1,4 @@
+#!/usr/bin/env -S jq -f
 . as $cfg
 | (
   # Build context_map as an array of objects with name transformations.


### PR DESCRIPTION
Having a kubeconfig with:
```yaml
contexts:
- name: ctx1
  context:
    user: username
    cluster: clustername
users:
- name: username
clusters:
- name: clustername
current-context: ctx1
```

The `rename-kubeconfig-ctx.jq` script renames the entities as the following:
```yaml
contexts:
- name: clustername // <- ctx1
  context:
    user: username@clustername // <- username
    cluster: clustername
users:
- name: username@clustername // <- username
clusters:
- name: clustername
current-context: clustername // <- ctx1
```
